### PR TITLE
Add full story analysis tests

### DIFF
--- a/src/ai/flows/generate-sound-design.ts
+++ b/src/ai/flows/generate-sound-design.ts
@@ -1,0 +1,29 @@
+'use server';
+
+// Simple placeholder flow for tests
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
+import { SoundEffectSchema } from '@/ai/schemas';
+
+const GenerateSoundDesignInputSchema = z.object({
+  storyText: z.string().describe('Full story text'),
+});
+export type GenerateSoundDesignInput = z.infer<typeof GenerateSoundDesignInputSchema>;
+
+const GenerateSoundDesignOutputSchema = z.object({
+  soundEffects: z.array(SoundEffectSchema),
+});
+export type GenerateSoundDesignOutput = z.infer<typeof GenerateSoundDesignOutputSchema>;
+
+export async function generateSoundDesign(input: GenerateSoundDesignInput): Promise<GenerateSoundDesignOutput> {
+  return generateSoundDesignFlow(input);
+}
+
+const generateSoundDesignFlow = ai.defineFlow({
+  name: 'generateSoundDesignFlow',
+  inputSchema: GenerateSoundDesignInputSchema,
+  outputSchema: GenerateSoundDesignOutputSchema,
+}, async (input) => {
+  // Placeholder implementation for tests
+  return { soundEffects: [] };
+});


### PR DESCRIPTION
## Summary
- add missing generate-sound-design flow stub so imports resolve
- extend actions tests with coverage for `getFullStoryAnalysis` and `generateElevenLabsAudio`

## Testing
- `npm test` *(fails: No `analyzeStoryPacing` export in mocked module)*

------
https://chatgpt.com/codex/tasks/task_e_68863d0490b48324bb13ed10fc3887c7