### PR TITLE
Implement sound design flow

### DIFF
--- a/src/ai/dev.ts
+++ b/src/ai/dev.ts
@@ -25,4 +25,5 @@ import '@/ai/flows/analyze-character-archetypes.ts';
 import '@/ai/flows/analyze-plot-structure.ts';
 import '@/ai/flows/compare-to-classics.ts';
 import '@/ai/flows/generate-elevenlabs-tts.ts';
+import '@/ai/flows/generate-sound-design.ts';
 // Deleting generate-character-brief.ts as it is now redundant.

--- a/src/ai/flows/generate-sound-design.ts
+++ b/src/ai/flows/generate-sound-design.ts
@@ -1,0 +1,48 @@
+'use server';
+
+/**
+ * @fileOverview Implements an AI-driven flow that scans story text for sound effect cues.
+ *
+ * - generateSoundDesign - Generates suggested sound effects for a story.
+ * - GenerateSoundDesignInput - The input type for the function.
+ * - GenerateSoundDesignOutput - The return type for the function.
+ */
+
+import { ai } from '@/ai/genkit';
+import { z } from 'genkit';
+import { SoundEffectSchema } from '@/ai/schemas';
+
+const GenerateSoundDesignInputSchema = z.object({
+  storyText: z.string().describe('The full text of the story to analyze for sound cues.'),
+});
+export type GenerateSoundDesignInput = z.infer<typeof GenerateSoundDesignInputSchema>;
+
+const GenerateSoundDesignOutputSchema = z.object({
+  soundEffects: z.array(SoundEffectSchema),
+});
+export type GenerateSoundDesignOutput = z.infer<typeof GenerateSoundDesignOutputSchema>;
+
+export async function generateSoundDesign(
+  input: GenerateSoundDesignInput
+): Promise<GenerateSoundDesignOutput> {
+  return generateSoundDesignFlow(input);
+}
+
+const generateSoundDesignFlow = ai.defineFlow(
+  {
+    name: 'generateSoundDesignFlow',
+    inputSchema: GenerateSoundDesignInputSchema,
+    outputSchema: GenerateSoundDesignOutputSchema,
+  },
+  async (input) => {
+    const prompt = ai.definePrompt({
+      name: 'soundDesignPrompt',
+      input: { schema: GenerateSoundDesignInputSchema },
+      output: { schema: GenerateSoundDesignOutputSchema },
+      prompt: `You are a sound designer creating an audio drama. Examine the story text and identify places where a specific sound effect would enhance the experience.\n\nFor each cue, return:\n- \\"segmentIndex\\": the zero-based index of the segment where the sound occurs.\n- \\"description\\": a short explanation of what produces the sound.\n- \\"soundQuery\\": a concise search query one could use in a sound effects library.\n\nRespond with JSON in the shape { "soundEffects": [ ... ] }. If no sound effects are found, return an empty array.\n\nStory text:\n\`\`\`\n{{{storyText}}}\n\`\`\``,
+    });
+
+    const { output } = await prompt(input);
+    return output!;
+  }
+);

--- a/src/lib/actions.test.ts
+++ b/src/lib/actions.test.ts
@@ -301,5 +301,13 @@ describe('Server Actions Tests', () => {
             expect(generateSoundDesignFlow).toHaveBeenCalledWith({ storyText });
             expect(result).toEqual([{ ...mockResult.soundEffects[0], soundUrl: placeholderSoundUrl }]);
         });
+
+        it('should return an empty array if the flow fails', async () => {
+            const storyText = 'A door creaked.';
+            (generateSoundDesignFlow as vi.Mock).mockRejectedValue(new Error('AI failed'));
+
+            const result = await getSoundDesign(storyText);
+            expect(result).toEqual([]);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- add generateSoundDesign AI flow
- register sound design flow in dev environment
- expand actions unit tests with sound design failure case

## Testing
- `pnpm install`
- `pnpm test` *(fails: reference errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68863cff68108324a50aebdf74c89953